### PR TITLE
[buteo-sync-plugin-caldav] Don't touch alarm duration on export. Cont…

### DIFF
--- a/src/incidencehandler.cpp
+++ b/src/incidencehandler.cpp
@@ -151,26 +151,6 @@ KCalendarCore::Incidence::Ptr IncidenceHandler::incidenceToExport(KCalendarCore:
         }
     }
 
-    // Icalformat from kcalcore converts second-type duration into day-type duration
-    // whenever possible. We do the same to have consistent comparisons.
-    const KCalendarCore::Alarm::List alarms = incidence->alarms();
-    for (KCalendarCore::Alarm::Ptr alarm : alarms) {
-        if (!alarm->hasTime()) {
-            KCalendarCore::Duration offset(0);
-            if (alarm->hasEndOffset())
-                offset = alarm->endOffset();
-            else
-                offset = alarm->startOffset();
-            if (!offset.isDaily() && !(offset.value() % (60 * 60 * 24))) {
-                LOG_DEBUG("Converting to day-type duration " << offset.asDays());
-                if (alarm->hasEndOffset())
-                    alarm->setEndOffset(KCalendarCore::Duration(offset.asDays(), KCalendarCore::Duration::Days));
-                else
-                    alarm->setStartOffset(KCalendarCore::Duration(offset.asDays(), KCalendarCore::Duration::Days));
-            }
-        }
-    }
-
     switch (incidence->type()) {
     case KCalendarCore::IncidenceBase::TypeEvent: {
         KCalendarCore::Event::Ptr event = incidence.staticCast<KCalendarCore::Event>();


### PR DESCRIPTION
This was necessary when using an exported version of incidence to compare it with an incoming incidence. Such comparisons are not in used anymore since etag addition is not marking an incidence as modified locally.

@chriadam what do you think ?

Some comments originally on https://git.sailfishos.org/mer-core/buteo-sync-plugin-caldav/merge_requests/81