### PR TITLE
[buteo-sync-plugin-caldav] Remove code adding occurrence as EXDATEs o…

### DIFF
--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.5.20
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.5.45
 BuildRequires:  pkgconfig(KF5CalendarCore) >= 5.79
 BuildRequires:  pkgconfig(buteosyncfw5) >= 0.10.0
 BuildRequires:  pkgconfig(accounts-qt5)

--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -94,8 +94,7 @@ private:
     bool updateIncidences(const QList<Reader::CalendarResource> &resources);
     bool deleteIncidences(const KCalendarCore::Incidence::List deletedIncidences);
     void updateIncidence(KCalendarCore::Incidence::Ptr incidence,
-                         KCalendarCore::Incidence::Ptr storedIncidence,
-                         const KCalendarCore::Incidence::List instances = KCalendarCore::Incidence::List());
+                         KCalendarCore::Incidence::Ptr storedIncidence);
     bool addIncidence(KCalendarCore::Incidence::Ptr incidence);
     bool addException(KCalendarCore::Incidence::Ptr incidence,
                       KCalendarCore::Incidence::Ptr recurringIncidence,


### PR DESCRIPTION
…n download.

After sailfishos/nemo-qml-plugin-calendar#3 will be accepted, there will be no need to add occurrences recurrenceIds as EXDATEs in the parent when receiving an incidence from the server. Technically, this MR is not mandatory after the QML one will be accepted. It's just that the removed code of this MR will be useless. Indeed, it will add EXDATEs to the parent, so the OccurrenceIterator used in the QML binding will not list the occurrences where there is exception in its internal loop and thus won't have to remove them from the public iteration knowing the exception list.

Sadly, we cannot yet remove the code for upload because the spurious EXDATEs are already present in the database.

@pvuorela and @chriadam, if you want to give a look.