### PR TITLE
[buteo-sync-plugin-caldav] Store error data per item logs. Contributes to JB#49486

### DIFF
--- a/src/delete.cpp
+++ b/src/delete.cpp
@@ -53,28 +53,15 @@ void Delete::deleteEvent(const QString &href)
             this, SLOT(slotSslErrors(QList<QSslError>)));
 }
 
-void Delete::requestFinished()
+void Delete::handleReply(QNetworkReply *reply)
 {
     FUNCTION_CALL_TRACE(lcCalDavTrace);
-
-    if (wasDeleted()) {
-        qCDebug(lcCalDav) << command() << "request was aborted";
-        return;
-    }
-
-    QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
-    if (!reply) {
-        finishedWithInternalError(QString());
-        return;
-    }
-    reply->deleteLater();
-    debugReplyAndReadAll(reply);
 
     const QString &uri = reply->property(PROP_INCIDENCE_URI).toString();
     if (reply->error() == QNetworkReply::ContentNotFoundError) {
         // Consider a success if the content does not exist on server.
         finishedWithSuccess(uri);
     } else {
-        finishedWithReplyResult(uri, reply->error());
+        finishedWithReplyResult(uri, reply);
     }
 }

--- a/src/delete.h
+++ b/src/delete.h
@@ -42,9 +42,8 @@ public:
 
     void deleteEvent(const QString &href);
 
-private Q_SLOTS:
-    void requestFinished();
-
+protected:
+    virtual void handleReply(QNetworkReply *reply);
 };
 
 #endif // DELETE_H

--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -142,8 +142,8 @@ private:
     KCalendarCore::Incidence::List mUpdatingList; // Incidences corresponding to mRemoteModifications
     QHash<QString, QString> mSentUids; // Dictionnary of sent (href, uid) made from
                                        // local additions, modifications.
-    QSet<QString> mFailingUploads; // List of hrefs with upload errors.
-    QSet<QString> mFailingUpdates; // List of hrefs from which incidences failed to update.
+    QHash<QString, QByteArray> mFailingUploads; // List of hrefs with upload errors, with the server response.
+    QHash<QString, QByteArray> mFailingUpdates; // List of hrefs from which incidences failed to update.
 
     // received remote incidence resource data
     QList<Reader::CalendarResource> mReceivedCalendarResources;

--- a/src/propfind.h
+++ b/src/propfind.h
@@ -67,8 +67,8 @@ public:
     void listCalendars(const QString &calendarsPath);
     const QList<CalendarInfo>& calendars() const;
 
-private Q_SLOTS:
-    void processResponse();
+protected:
+    virtual void handleReply(QNetworkReply *reply);
 
 private:
     enum PropFindRequestType {

--- a/src/put.cpp
+++ b/src/put.cpp
@@ -80,24 +80,9 @@ void Put::sendIcalData(const QString &uri, const QString &icalData,
             this, SLOT(slotSslErrors(QList<QSslError>)));
 }
 
-void Put::requestFinished()
+void Put::handleReply(QNetworkReply *reply)
 {
     FUNCTION_CALL_TRACE(lcCalDavTrace);
-
-    if (wasDeleted()) {
-        qCDebug(lcCalDav) << command() << "request was aborted";
-        return;
-    }
-
-    QNetworkReply *reply = qobject_cast<QNetworkReply*>(sender());
-    if (!reply) {
-        finishedWithInternalError(QString(), "Internal error: PUT request finished but null");
-        return;
-    }
-    reply->deleteLater();
-
-    qCDebug(lcCalDav) << "PUT request finished:" << reply->error();
-    debugReplyAndReadAll(reply);
 
     // If the put was denied by server (e.g. read-only calendar), the etag
     // is not updated, so NotebookSyncAgent::finalizeSendingLocalChanges()
@@ -113,7 +98,7 @@ void Put::requestFinished()
     }
     mLocalUriList.remove(uri);
 
-    finishedWithReplyResult(uri, reply->error());
+    finishedWithReplyResult(uri, reply);
 }
 
 QString Put::updatedETag(const QString &uri) const

--- a/src/put.h
+++ b/src/put.h
@@ -46,8 +46,8 @@ public:
 
     QString updatedETag(const QString &uri) const;
 
-private Q_SLOTS:
-    void requestFinished();
+protected:
+    virtual void handleReply(QNetworkReply *reply);
 
 private:
     QSet<QString> mLocalUriList;

--- a/src/report.h
+++ b/src/report.h
@@ -51,8 +51,8 @@ public:
     const QList<Reader::CalendarResource>& receivedCalendarResources() const;
     const QStringList& fetchedUris() const;
 
-private Q_SLOTS:
-    void processResponse();
+protected:
+    virtual void handleReply(QNetworkReply *reply);
 
 private:
     void sendRequest(const QString &remoteCalendarPath, const QByteArray &requestData);

--- a/src/request.h
+++ b/src/request.h
@@ -46,7 +46,8 @@ public:
 
     QString command() const;
     Buteo::SyncResults::MinorCode errorCode() const;
-    QString errorString() const;
+    QString errorMessage() const;
+    QByteArray errorData() const;
     QNetworkReply::NetworkError networkError() const;
 
 Q_SIGNALS:
@@ -54,16 +55,19 @@ Q_SIGNALS:
 
 protected Q_SLOTS:
     virtual void slotSslErrors(QList<QSslError>);
+    void requestFinished();
 
 protected:
     void prepareRequest(QNetworkRequest *request, const QString &requestPath);
+    virtual void handleReply(QNetworkReply *reply) = 0;
 
     bool wasDeleted() const;
 
     void finishedWithSuccess(const QString &uri);
-    void finishedWithError(const QString &uri, Buteo::SyncResults::MinorCode minorCode, const QString &errorString);
+    void finishedWithError(const QString &uri, Buteo::SyncResults::MinorCode minorCode,
+                           const QString &errorMessage, const QByteArray &errorData);
     void finishedWithInternalError(const QString &uri, const QString &errorString = QString());
-    void finishedWithReplyResult(const QString &uri, QNetworkReply::NetworkError error);
+    void finishedWithReplyResult(const QString &uri, QNetworkReply *reply);
 
     void debugRequest(const QNetworkRequest &request, const QByteArray &data);
     void debugRequest(const QNetworkRequest &request, const QString &data);
@@ -79,7 +83,8 @@ protected:
     QPointer<Request> mSelfPointer;
     QNetworkReply::NetworkError mNetworkError;
     Buteo::SyncResults::MinorCode mMinorCode;
-    QString mErrorString;
+    QString mErrorMessage;
+    QByteArray mErrorData;
 };
 
 #endif // REQUEST_H


### PR DESCRIPTION
Buteo logging has been able to store some arbitrary data per item. This PR is using these data to store raw error associated to an item.

In case of an error during upload, the server response is stored. In case on database error during download, some message are stored depending on the error case.

I've reworked all the request class and subclasses to be able to get and store the server messages and not just an error code.

@chriadam what is your opinion on this ?