### PR TITLE
[buteo-sync-plugin-caldav] Report error when etag fetching fails.

### DIFF
--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -103,7 +103,6 @@ private:
 
     void sendLocalChanges();
     QString constructLocalChangeIcs(KCalendarCore::Incidence::Ptr updatedIncidence);
-    void finalizeSendingLocalChanges();
 
     bool calculateDelta(const QHash<QString, QString> &remoteUriEtags,
                         KCalendarCore::Incidence::List *localAdditions,


### PR DESCRIPTION
In case the etag of a recently pushed incidence cannot be retrieved, there is no flagging of the error at the moment. The incidence is reported as being added properly on server, but since the etag is missing, it will be retried on next sync. This is not a fundamental sync error and at the end, the event will be on device and on server, but this is not very nice in the log.

This PR is adding error flagging of the upload when the etag cannot be retrieved.

@chriadam what do you think ?