### PR TITLE
Tests

### DIFF
--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -1267,11 +1267,13 @@ void NotebookSyncAgent::updateHrefETag(const QString &uid, const QString &href, 
 
     KCalendarCore::Incidence::Ptr localBaseIncidence = mCalendar->incidence(uid);
     if (localBaseIncidence) {
+        localBaseIncidence->update();
         updateIncidenceHrefEtag(localBaseIncidence, href, etag);
         localBaseIncidence->updated();
         if (localBaseIncidence->recurs()) {
             const KCalendarCore::Incidence::List instances = mCalendar->instances(localBaseIncidence);
             for (const KCalendarCore::Incidence::Ptr &instance : instances) {
+                instance->update();
                 updateIncidenceHrefEtag(instance, href, etag);
                 instance->updated();
             }

--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -1083,13 +1083,18 @@ bool NotebookSyncAgent::addException(KCalendarCore::Incidence::Ptr incidence,
                                      KCalendarCore::Incidence::Ptr recurringIncidence,
                                      bool ensureRDate)
 {
-    if (ensureRDate && recurringIncidence->allDay()
-        && !recurringIncidence->recursOn(incidence->recurrenceId().date(),
-                                         incidence->recurrenceId().timeZone())) {
-        recurringIncidence->recurrence()->addRDate(incidence->recurrenceId().date());
-    } else if (ensureRDate && !recurringIncidence->allDay()
-               && !recurringIncidence->recursAt(incidence->recurrenceId())) {
-        recurringIncidence->recurrence()->addRDateTime(incidence->recurrenceId());
+    if (ensureRDate) {
+        const QDateTime lastModified = recurringIncidence->lastModified();
+        if (recurringIncidence->allDay()
+            && !recurringIncidence->recursOn(incidence->recurrenceId().date(),
+                                             incidence->recurrenceId().timeZone())) {
+            recurringIncidence->recurrence()->addRDate(incidence->recurrenceId().date());
+            recurringIncidence->setLastModified(lastModified);
+        } else if (!recurringIncidence->allDay()
+                   && !recurringIncidence->recursAt(incidence->recurrenceId())) {
+            recurringIncidence->recurrence()->addRDateTime(incidence->recurrenceId());
+            recurringIncidence->setLastModified(lastModified);
+        }
     }
 
     return addIncidence(incidence);


### PR DESCRIPTION
It seems I didn't run the NotebookSyncAgent tests for a while ;) A certain amount of tests were failing because of recent modifications in mKCal:
* various local notebooks were not added to the storage, which made the notebook validation check failed,
* notebook incidences were deleted in the clean() routine before being saved,
* one recurrence id was created with milliseconds, making the `recursOn()` test failed,
* `dissociateSingleOccurrence()` was called on a calendar in the `_data()` routine before the calendar initialisation,

I pushed two commits also to actually correct mistakes in the main code, but with very minor consequences:
* forgot to call `update()` before `updated()`. That was possible for a Calendar, but it is not any more for a MemoryCalendar. It is without effect though, besides generating a warning at runtime. (it is strange that it is possible not to call it from Calendar but not anymore for MemoryCalendar, anyway, it's an upstream problem that I may look at later),
* in the case of orphaned exception, creating the RDate for the fake parent was spuriously updating its lastModified stamp which made it appear at next sync. Not a big deal neither : orphaned exceptions should not happen anyway.

@chriadam what do you think ?