### PR TITLE
[buteo-sync-plugin-caldav] Don't delete canceled events.

### DIFF
--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -12,7 +12,7 @@ BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
 BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.5.45
 BuildRequires:  pkgconfig(KF5CalendarCore) >= 5.79
-BuildRequires:  pkgconfig(buteosyncfw5) >= 0.10.0
+BuildRequires:  pkgconfig(buteosyncfw5) >= 0.10.11
 BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(signon-oauth2plugin)
 BuildRequires:  pkgconfig(QmfClient)


### PR DESCRIPTION
There is a mistake putting the canceled event on server in the wrong list for local deletion. It is the `mRemoteDeletions` list that is used to delete copies from device.

Alos bump the requirement on `buteo-syncfw` because the new minor item values from some previous commit require 0.10.11.

@chriadam when you have time to give a look, thank you in advance.