### PR TITLE
[buteo-caldav] Adjust the feature name of the unit tests. JB#60293

### DIFF
--- a/tests/tests.xml
+++ b/tests/tests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testdefinition version="1.0">
   <suite name="buteo-sync-plugin-caldav-tests" domain="mw">
-    <set name="unit-tests" feature="calendar sync">
+    <set name="unit-tests" feature="buteo-caldav">
       <case manual="false" name="reader">
         <step>/usr/sbin/run-blts-root /bin/su $USER -g privileged -c /opt/tests/buteo/plugins/caldav/tst_reader</step>
       </case>


### PR DESCRIPTION
Due to test setup these were appearing under a section "calendar sync" which is vague wording for caldav.

cc @dcaliste . The tests do pass now btw.