### PR TITLE
Remove msyncd restart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.pro.user
 *.pro.user.*
 moc_*.cpp
+*.moc
 qrc_*.cpp
 Makefile
 *-build-*

--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -1,6 +1,6 @@
 Name:       buteo-sync-plugin-caldav
 Summary:    Syncs calendar data from CalDAV services
-Version:    0.3.1
+Version:    0.3.7
 Release:    1
 License:    LGPLv2
 URL:        https://github.com/sailfishos/buteo-sync-plugin-caldav/
@@ -76,14 +76,6 @@ This package contains unit tests for the CalDAV Buteo sync plugin.
 %qmake5
 make %{?_smp_mflags}
 
-%pre
-# remove legacy files
-rm -f /home/nemo/.cache/msyncd/sync/client/caldav.xml || :
-rm -f /home/nemo/.cache/msyncd/sync/caldav-sync.xml || :
-
 %install
-rm -rf %{buildroot}
 %qmake5_install
 
-%post
-systemctl-user try-restart msyncd.service || :


### PR DESCRIPTION
The sync plugin is out-of-process getting executed when needed.
Restarting msyncd for user session shouldn't matter that much.
Also legacy files are removed years ago already.

@dcaliste 