### PR TITLE
[buteo-sync-plugin-caldav] Fix upsync of imported exceptions.

### DIFF
--- a/tests/notebooksyncagent/tst_notebooksyncagent.cpp
+++ b/tests/notebooksyncagent/tst_notebooksyncagent.cpp
@@ -435,6 +435,7 @@ void tst_NotebookSyncAgent::calculateDelta()
     m_agent->mCalendar->addEvent(ev777.staticCast<KCalendarCore::Event>(),
                                  m_agent->mNotebook->uid());
     KCalendarCore::Incidence::Ptr ev888 = KCalendarCore::Incidence::Ptr(new KCalendarCore::Event);
+    ev888->setUid("888");
     ev888->setRecurrenceId(QDateTime());
     ev888->addComment(QStringLiteral("buteo:caldav:uri:%1888.ics").arg(m_agent->mRemoteCalendarPath));
     ev888->addComment(QStringLiteral("buteo:caldav:etag:\"%1\"").arg("etag888"));
@@ -444,8 +445,15 @@ void tst_NotebookSyncAgent::calculateDelta()
                         recId.time().minute(),
                         recId.time().second()));
     ev888->setDtStart( recId );
-    ev888->recurrence()->addRDateTime(recId);
+    ev888->recurrence()->addRDateTime(recId.addDays(1));
     m_agent->mCalendar->addEvent(ev888.staticCast<KCalendarCore::Event>(),
+                                 m_agent->mNotebook->uid());
+    KCalendarCore::Incidence::Ptr ev889(ev888->clone());
+    ev889->setRecurrenceId(recId.addDays(1));
+    ev889->clearRecurrence();
+    ev889->setSummary("import exception to ev888");
+    ev889->clearComments(); // Imported exceptions don't have URI and ETAG from parent
+    m_agent->mCalendar->addEvent(ev889.staticCast<KCalendarCore::Event>(),
                                  m_agent->mNotebook->uid());
     KCalendarCore::Incidence::Ptr ev112 = KCalendarCore::Incidence::Ptr(new KCalendarCore::Event);
     ev112->setSummary("partial local addition, need download");
@@ -517,9 +525,10 @@ void tst_NotebookSyncAgent::calculateDelta()
                                     &m_agent->mLocalDeletions,
                                     &m_agent->mRemoteChanges,
                                     &m_agent->mRemoteDeletions));
-    QCOMPARE(m_agent->mLocalAdditions.count(), 2);
+    QCOMPARE(m_agent->mLocalAdditions.count(), 3);
     QVERIFY(incidenceListContains(m_agent->mLocalAdditions, ev111));
     QVERIFY(incidenceListContains(m_agent->mLocalAdditions, ev999));
+    QVERIFY(incidenceListContains(m_agent->mLocalAdditions, ev889));
     QCOMPARE(m_agent->mLocalModifications.count(), 2);
     QVERIFY(incidenceListContains(m_agent->mLocalModifications, ev222));
     QVERIFY(incidenceListContains(m_agent->mLocalModifications, ev113));


### PR DESCRIPTION
The sync code relies on the fact that added
exceptions on device inherit the URI and ETAG
of the parent, when the dissociation code is
called.

This assumption is not true when importing
an exception, like a cancel event received
by email for instance.

This commit ensures that such an imported
event is actually seen as a local addition
and that the ETAG used to push the event to
the server is using the ETAG of the parent.

@pvuorela, this is fixing the issue for me, where previously the lack of URI and ETAG in the imported exception was making the sync code to treat it as a non fully upsync event, not modified on device, and was thus scratched by downloading the server version to get the ETAG. URI and ETAG are custom properties saved by the sync plugin to get track of upsynced incidences.

This issue may impact other sync plugin, those relying on custom properties copied from the parent to the exception when created on device, I don't know. Another way of fixing the issue would be to modify the import code in nemo-qml-plugin-calendar in a way, that when importing an exception, the event is not added directly to the calendar, but follow the same route as created exceptions:
- dissociate an occurence from the parent at the given date,
- merge the imported exception into the occurrence (copy everything but keep existing custom properties)
- add the occurrence to the calendar.

The problem is that this "merge" action does not exist in KCalendarCore API and is a bit ugly to add.

What's your opinion ?