### PR TITLE
Specify the notebook when purging and two other cleaning commits

### DIFF
--- a/rpm/buteo-sync-plugin-caldav.spec
+++ b/rpm/buteo-sync-plugin-caldav.spec
@@ -10,7 +10,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Network)
 BuildRequires:  pkgconfig(libsignon-qt5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
-BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.6
+BuildRequires:  pkgconfig(libmkcal-qt5) >= 0.7.17
 BuildRequires:  pkgconfig(KF5CalendarCore) >= 5.79
 BuildRequires:  pkgconfig(buteosyncfw5) >= 0.10.11
 BuildRequires:  pkgconfig(accounts-qt5)

--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -763,7 +763,8 @@ bool NotebookSyncAgent::applyRemoteChanges()
     if (!mStorage->save(mKCal::ExtendedStorage::PurgeDeleted)) {
         success = false;
     }
-    if (!mPurgeList.isEmpty() && !mStorage->purgeDeletedIncidences(mPurgeList)) {
+    if (!mPurgeList.isEmpty() && !mStorage->purgeDeletedIncidences(mPurgeList,
+                                                                   notebook->uid())) {
         // Silently ignore failed purge action in database.
         qCWarning(lcCalDav) << "Cannot purge from database the marked as deleted incidences.";
     }

--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -750,8 +750,6 @@ bool NotebookSyncAgent::applyRemoteChanges()
     }
 
     bool success = true;
-    // Make notebook writable for the time of the modifications.
-    notebook->setIsReadOnly(false);
     if ((mEnableDownsync || mSyncMode == SlowSync)
         && !updateIncidences(mReceivedCalendarResources)) {
         success = false;


### PR DESCRIPTION
@pvuorela, this is a folow-up of sailfishos/mkcal#59. It comes also with two other commits:
- one is removing the read-only flag change before writing that is not necessary anymore since a while with mKCal allowing to write changes to read-only notebooks without resetting the flag.
- the other is simplifying the ICS data construction inn case of recurring event with exceptions. The construction looks very convoluted to me, mimicking the creation of an exception to then scratch it with the real provided exception.