### PR TITLE
[buteo-sync-plugin-caldav] Correct URL in case of mangled UIDs.

### DIFF
--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -69,7 +69,12 @@ namespace {
     }
     QString createIncidenceHrefUri(KCalendarCore::Incidence::Ptr incidence, const QString &remoteCalendarPath)
     {
-        return remoteCalendarPath + incidence->uid() + ".ics";
+        if (incidence->uid().startsWith(QString::fromLatin1("NBUID:"))) {
+            const QString uid = incidence->uid();
+            return remoteCalendarPath + uid.mid(uid.indexOf(':', 6)+1) + ".ics"; // remove NBUID:NotebookUid:
+        } else {
+            return remoteCalendarPath + incidence->uid() + ".ics";
+        }
     }
     void setIncidenceHrefUri(KCalendarCore::Incidence::Ptr incidence, const QString &hrefUri)
     {


### PR DESCRIPTION
When receiving a new incidence from upstream,
the UID is mangled with the notebook UID to avoid
collision with an existing UID in another notebook.

The URL of the received incidence is stored with
the incidence, so when modifying such incidence
the update is sent to the correct URL and not
one created from the mangled UID.

Unfortunately, creating an exception for such a
recurring incidence on device, will not copy
the URL (as it is stored in comments) and when
pushing the exception to the server, the mangled
UID is used to forge the URL, which is faulty.

See calendarworker.cpp in nemo-qml-plugin-calendar, the dissociateSingleOccurrence() call is properly
copying the comments, but the information is not
passed to the manager via CalendarData::Event
structure. Then, when saving the event in saveEvent(), the proper URL is lost.

@pvuorela, it's a bit strange that I didn't notice it before. The case of having a recurring event coming for upstream and then adding an exception on device was something I only did yesterday, apparently. I was truly convinced that comments were copied in the QML bindings and I needed to reread the code there several times to see that it cannot because the Event struct does not possess such a field. The fix should be in Buteo CalDAV plugin though, because there is no way for the QML bindings to know that comments are holding important code for the sync process.