### PR TITLE
[buteo-sync-plugin-caldav] Retrieve allowed components per calendar.

### DIFF
--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -689,6 +689,9 @@ void CalDavClient::syncCalendars(const QList<PropFind::CalendarInfo> &allCalenda
         if (!agent->setNotebookFromInfo(calendarInfo.displayName,
                                         calendarInfo.color,
                                         email,
+                                        calendarInfo.allowEvents,
+                                        calendarInfo.allowTodos,
+                                        calendarInfo.allowJournals,
                                         QString::number(mAccountId),
                                         getPluginName(),
                                         getProfileName())) {

--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -316,6 +316,7 @@ static const QByteArray SERVER_COLOR_PROPERTY = QByteArrayLiteral("serverColor")
 bool NotebookSyncAgent::setNotebookFromInfo(const QString &notebookName,
                                             const QString &color,
                                             const QString &userEmail,
+                                            bool allowEvents, bool allowTodos, bool allowJournals,
                                             const QString &accountId,
                                             const QString &pluginName,
                                             const QString &syncProfile)
@@ -342,6 +343,9 @@ bool NotebookSyncAgent::setNotebookFromInfo(const QString &notebookName,
             mNotebook->setSyncProfile(syncProfile);
             mNotebook->setCustomProperty(EMAIL_PROPERTY, userEmail);
             mNotebook->setPluginName(pluginName);
+            mNotebook->setEventsAllowed(allowEvents);
+            mNotebook->setTodosAllowed(allowTodos);
+            mNotebook->setJournalsAllowed(allowJournals);
             return true;
         }
     }
@@ -357,6 +361,9 @@ bool NotebookSyncAgent::setNotebookFromInfo(const QString &notebookName,
         mNotebook->setColor(color);
         mNotebook->setCustomProperty(SERVER_COLOR_PROPERTY, color);
     }
+    mNotebook->setEventsAllowed(allowEvents);
+    mNotebook->setTodosAllowed(allowTodos);
+    mNotebook->setJournalsAllowed(allowJournals);
     return true;
 }
 

--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -58,6 +58,7 @@ public:
     bool setNotebookFromInfo(const QString &notebookName,
                              const QString &color,
                              const QString &userEmail,
+                             bool allowEvents, bool allowTodos, bool allowJournals,
                              const QString &accountId,
                              const QString &pluginName,
                              const QString &syncProfile);

--- a/src/propfind.h
+++ b/src/propfind.h
@@ -39,9 +39,12 @@ public:
         QString displayName;
         QString color;
         QString userPrincipal;
-        bool readOnly;
+        bool readOnly = false;
+        bool allowEvents = true;
+        bool allowTodos = true;
+        bool allowJournals = true;
 
-        CalendarInfo() : readOnly(false) {};
+        CalendarInfo() {};
         CalendarInfo(const QString &path, const QString &name, const QString &color,
                      const QString &principal = QString(), bool readOnly = false)
             : remotePath(path), displayName(name), color(color)
@@ -51,7 +54,11 @@ public:
             return (remotePath == other.remotePath
                     && displayName == other.displayName
                     && color == other.color
-                    && userPrincipal == other.userPrincipal);
+                    && userPrincipal == other.userPrincipal
+                    && readOnly == other.readOnly
+                    && allowEvents == other.allowEvents
+                    && allowTodos == other.allowTodos
+                    && allowJournals == other.allowJournals);
         }
     };
 

--- a/tests/propfind/tst_propfind.cpp
+++ b/tests/propfind/tst_propfind.cpp
@@ -252,6 +252,27 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar 1"),
                     QString::fromLatin1("#FFFF00"),
                     QString::fromLatin1("/principals/users/username%40server.tld/")});
+
+    PropFind::CalendarInfo todos(QString::fromLatin1("/calendars/0/"),
+                                 QString::fromLatin1("Calendar 0"),
+                                 QString::fromLatin1("#FF0000"),
+                                 QString::fromLatin1("/principals/users/username%40server.tld/"));
+    todos.allowEvents = false;
+    todos.allowTodos = true;
+    todos.allowJournals = false;
+    QTest::newRow("one valid task manager")
+        << QByteArray("<?xml version='1.0' encoding='utf-8'?><D:multistatus xmlns:D='DAV:' xmlns:c='urn:ietf:params:xml:ns:caldav'><D:response><D:href>/calendars/0/</D:href><D:propstat><D:prop><D:displayname>Calendar 0</D:displayname><calendar-color xmlns=\"http://apple.com/ns/ical/\">#FF0000</calendar-color><D:resourcetype><c:calendar /><D:collection /></D:resourcetype><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal><D:current-user-privilege-set><D:privilege><D:read /></D:privilege><D:privilege><D:write /></D:privilege></D:current-user-privilege-set><c:supported-calendar-component-set><c:comp name=\"VTODO\" /></c:supported-calendar-component-set></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>")
+        << true
+        << (QList<PropFind::CalendarInfo>() << todos);
+
+    QTest::newRow("missing component set")
+        << QByteArray("<?xml version='1.0' encoding='utf-8'?><D:multistatus xmlns:D='DAV:' xmlns:c='urn:ietf:params:xml:ns:caldav'><D:response><D:href>/calendars/0/</D:href><D:propstat><D:prop><calendar-color xmlns=\"http://apple.com/ns/ical/\">#FF0000</calendar-color><D:resourcetype><c:calendar /><D:collection /></D:resourcetype><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat><D:propstat><D:prop><c:supported-calendar-component-set /></D:prop><D:status>HTTP/1.1 404</D:status></D:propstat></D:response></D:multistatus>")
+        << true
+        << (QList<PropFind::CalendarInfo>() << PropFind::CalendarInfo{
+                QString::fromLatin1("/calendars/0/"),
+                    QString::fromLatin1("Calendar"),
+                    QString::fromLatin1("#FF0000"),
+                    QString::fromLatin1("/principals/users/username%40server.tld/")});
 }
 
 void tst_Propfind::parseCalendarResponse()


### PR DESCRIPTION
Use propfind method 'supported-calendar-component-set' to inquire the allowed components, like only VTODOS for task calendars for instance.

These properties are not used to filter out
downsynced or upsynced components yet. The
information is stored to mKCal though and
may be used at UI level to hide calendars
not suited for VEVENT storage.

@pvuorela, this comes out of a discussion on the forum, when using a Nextcloud account for instance, the special "Tasks" calendar is restricted for `VTODO` components but is listed in the calendar list page in the calendar application and in the account setting, while it is not possible to up sync any event to this calendar.
https://forum.sailfishos.org/t/nextcloud-account-sync-errors-local-to-remote-remote-calendars-sync-both-ways/15791/33