### PR TITLE
[buteo-sync-plugin-caldav] Avoid '/' character in URLs coming from lo…

### DIFF
--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -73,7 +73,11 @@ namespace {
             const QString uid = incidence->uid();
             return remoteCalendarPath + uid.mid(uid.indexOf(':', 6)+1) + ".ics"; // remove NBUID:NotebookUid:
         } else {
-            return remoteCalendarPath + incidence->uid() + ".ics";
+            // In case UID is coming from an importation it can be
+            // whatever. A proper sanitation woud be to use QUrl::toPercentEncoding()
+            // but the percent encoded '/' character is creating issue with
+            // some server in multiget requests.
+            return remoteCalendarPath + incidence->uid().replace('/', '-') + ".ics";
         }
     }
     void setIncidenceHrefUri(KCalendarCore::Incidence::Ptr incidence, const QString &hrefUri)


### PR DESCRIPTION
…cal UIDs.

When an incidence is imported, its UID can be anything. If it contains '/' characters, pushing this event to an URL created from the UID will fail. Simply replace '/' with '-' when forging an URL for a locally added
incidence.

@pvuorela , I found another faulty corner case. I imported a event with an UID like `11/07/2023 08:30:00damien.caliste@cea.frEvènement : entretiens vélos personnels0,70554750,533424` (I received it as a meeting appointment from my work).I checked the RFC5545, and it seems that UID can contain '/' characters. Of course pushing such an event to the server at a URL forged from the UID, like `/caldav/Y2FsOi8vMC80NQ/11/07/2023...` failed. As mentioned in the comment, I first tried to percent encode the UID, which work when sending the event to the server. But the multiget request (to get the etag) to the percent encoded URL returned a 404 error, because it decoded the URL server-side and tried to look for something at `/caldav/Y2FsOi8vMC80NQ/11/07/2023...`. I'm not sure if it's an issue from the server or if we should double encode the URL in the multiget request. But the simpler solution was to just replace any '/' with something less harmfull.