### PR TITLE
[buteo-sync-plugin-caldav] Simplify authentication using AccountService.

### DIFF
--- a/src/authhandler.h
+++ b/src/authhandler.h
@@ -75,7 +75,6 @@ private:
     QString mToken;
     QString mUsername;
     QString mPassword;
-    QString mMethod, mMechanism;
     QString m_accountService;
 };
 

--- a/src/authhandler.h
+++ b/src/authhandler.h
@@ -25,6 +25,7 @@
 #define AUTHHANDLER_H
 
 #include <QObject>
+#include <QSharedPointer>
 
 #include <SyncCommonDefs.h>
 #include <SyncProfile.h>
@@ -38,7 +39,7 @@ class AuthHandler : public QObject
 {
     Q_OBJECT
 public:
-    explicit AuthHandler(Accounts::Manager *manager, const quint32 accountId, const QString &accountService, QObject *parent = 0);
+    explicit AuthHandler(QSharedPointer<Accounts::AccountService> service, QObject *parent = 0);
 
     void authenticate();
     const QString token();
@@ -56,11 +57,6 @@ private:
     void deviceAuth();
     void processDeviceCode(const QByteArray &deviceCodeJSON);
 
-    QString	iDeviceCode;
-    QString iUserCode;
-    QString iVerificationURL;
-    QString iToken;
-
     QString storedKeyValue(const char *provider, const char *service, const char *keyName);
 
 private Q_SLOTS:
@@ -70,12 +66,10 @@ private Q_SLOTS:
 private:
     SignOn::Identity    *mIdentity;
     SignOn::AuthSession *mSession;
-    Accounts::Manager   *mAccountManager;
-    Accounts::Account   *mAccount;
+    QSharedPointer<Accounts::AccountService> mAccountService;
     QString mToken;
     QString mUsername;
     QString mPassword;
-    QString m_accountService;
 };
 
 #endif // AUTHHANDLER_H

--- a/src/caldavclient.h
+++ b/src/caldavclient.h
@@ -33,6 +33,7 @@
 #include <QList>
 #include <QSet>
 #include <QScopedPointer>
+#include <QSharedPointer>
 
 #include <extendedstorage.h>
 
@@ -147,11 +148,9 @@ private:
     void closeConfig();
     void syncFinished(Buteo::SyncResults::MinorCode minorErrorCode, const QString &message = QString());
     void clearAgents();
-    bool deleteNotebook(int accountId, mKCal::ExtendedCalendar::Ptr calendar, mKCal::ExtendedStorage::Ptr storage, mKCal::Notebook::Ptr notebook);
     void deleteNotebooksForAccount(int accountId, mKCal::ExtendedCalendar::Ptr calendar, mKCal::ExtendedStorage::Ptr storage);
-    bool cleanSyncRequired(int accountId);
+    bool cleanSyncRequired();
     void getSyncDateRange(const QDateTime &sourceDate, QDateTime *fromDateTime, QDateTime *toDateTime);
-    Accounts::Account* getAccountForCalendars(Accounts::Service *service) const;
     QList<PropFind::CalendarInfo> loadAccountCalendars() const;
     QList<PropFind::CalendarInfo> mergeAccountCalendars(const QList<PropFind::CalendarInfo> &calendars) const;
     void removeAccountCalendars(const QStringList &paths);
@@ -161,12 +160,13 @@ private:
     Buteo::SyncProfile::SyncDirection syncDirection();
     Buteo::SyncProfile::ConflictResolutionPolicy conflictResolutionPolicy();
 
-    void setCredentialsNeedUpdate(int accountId);
+    void setCredentialsNeedUpdate();
 
     mutable QScopedPointer<Sailfish::KeyProvider::ProcessMutex> mProcessMutex;
     QList<NotebookSyncAgent *>  mNotebookSyncAgents;
     QNetworkAccessManager*      mNAManager;
     Accounts::Manager*          mManager;
+    QSharedPointer<Accounts::AccountService> mService;
     AuthHandler*                mAuth;
     mKCal::ExtendedCalendar::Ptr mCalendar;
     mKCal::ExtendedStorage::Ptr mStorage;
@@ -175,7 +175,6 @@ private:
     Buteo::SyncProfile::SyncDirection mSyncDirection;
     Buteo::SyncProfile::ConflictResolutionPolicy mConflictResPolicy;
     Settings                    mSettings;
-    int                         mAccountId;
 
     friend class tst_CalDavClient;
 };

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -24,8 +24,7 @@
 #include "settings.h"
 
 Settings::Settings()
-    : mAccountId(0)
-    , mIgnoreSSLErrors(false)
+    : mIgnoreSSLErrors(false)
 {
 }
 
@@ -67,16 +66,6 @@ QString Settings::username() const
 void Settings::setUsername(const QString & username)
 {
     mUsername = username;
-}
-
-void Settings::setAccountId(quint32 accountId)
-{
-    mAccountId = accountId;
-}
-
-quint32 Settings::accountId() const
-{
-    return mAccountId;
 }
 
 void Settings::setServerAddress(const QString &serverAddress)

--- a/src/settings.h
+++ b/src/settings.h
@@ -44,9 +44,6 @@ public:
     void setIgnoreSSLErrors(bool ignore);
     bool ignoreSSLErrors() const;
 
-    void setAccountId(quint32 accountId);
-    quint32 accountId() const;
-
     void setServerAddress(const QString &serverAddress);
     QString serverAddress() const;
 
@@ -67,7 +64,6 @@ private:
     QString mOAuthToken;
     QString mUsername;
     QString mPassword;
-    quint32 mAccountId;
     bool mIgnoreSSLErrors;
 };
 

--- a/tests/caldavclient/tst_caldavclient.cpp
+++ b/tests/caldavclient/tst_caldavclient.cpp
@@ -24,6 +24,7 @@
 #include "caldavclient.h"
 
 #include <ProfileEngineDefs.h>
+#include <Accounts/AccountService>
 
 class tst_CalDavClient : public QObject
 {
@@ -107,8 +108,8 @@ void tst_CalDavClient::initConfig()
     CalDavClient client(QLatin1String("caldav"), mProfile, nullptr);
 
     QVERIFY(client.init());
-    QCOMPARE(client.mAccountId, int(mAccount->id()));
-    QCOMPARE(client.mSettings.accountId(), mAccount->id());
+    QVERIFY(client.mService);
+    QCOMPARE(client.mService->account()->id(), mAccount->id());
     QCOMPARE(client.mSettings.serverAddress(), SERVER_ADDRESS);
     QVERIFY(client.mSettings.ignoreSSLErrors());
 }


### PR DESCRIPTION
Instead of switching the service by hand and looking at settings from their keys, use Accounts::AccountService that provide a Accounts::AuthData that can be used to directly interacts with signon objects.

I've tested it with the password method for my caldav account.