### PR TITLE
[buteo-sync-plugin-caldav] Fallback to account settings if not in ser…

### DIFF
--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -442,13 +442,17 @@ bool CalDavClient::initConfig()
         return false;
     }
 
-    mSettings.setServerAddress(mService->value("server_address").toString());
+    Accounts::AccountService global(mService->account(), Accounts::Service());
+    mSettings.setServerAddress(mService->value("server_address",
+                                               global.value("server_address")).toString());
     if (mSettings.serverAddress().isEmpty()) {
         qCWarning(lcCalDav) << "remote_address not found in service settings";
         return false;
     }
-    mSettings.setDavRootPath(mService->value("webdav_path").toString());
-    mSettings.setIgnoreSSLErrors(mService->value("ignore_ssl_errors").toBool());
+    mSettings.setDavRootPath(mService->value("webdav_path",
+                                             global.value("webdav_path")).toString());
+    mSettings.setIgnoreSSLErrors(mService->value("ignore_ssl_errors",
+                                                 global.value("ignore_ssl_errors")).toBool());
 
     mAuth = new AuthHandler(mService, this);
     if (!mAuth->init()) {


### PR DESCRIPTION
…vice.

Server settings are primarily read from account service parameters, but add a fallback to account wide parameters if not found.

This is not required for Sailfish OS. We store the server settings per service. But UBports is storing the server settings globally in the account. To reduce the patches they have to apply, I'm proposing to simply add a fallback with the account values when the per-service ones are not found. It should not impact negatively Sailfish OS behaviour, while it can provide a safe fallback in case there is some change in the policy for the server settings parameters storage.

What do you think about it, @pvuorela ?