### PR TITLE
[buteo-sync-plugin-caldav] Ensure correct percent encoding for paths.…

### DIFF
--- a/lib/request.cpp
+++ b/lib/request.cpp
@@ -147,7 +147,14 @@ void Request::prepareRequest(QNetworkRequest *request, const QString &requestPat
         url.setUserName(mSettings->username());
         url.setPassword(mSettings->password());
     }
-    url.setPath(requestPath);
+    // If the server returns paths in percent-encoded form,
+    // avoid double encoding when calling QUrl::setPath()
+    // by using the strict mode.
+    if (requestPath.contains('%')) {
+        url.setPath(requestPath, QUrl::StrictMode);
+    } else {
+        url.setPath(requestPath);
+    }
     request->setUrl(url);
 }
 


### PR DESCRIPTION
… Contributes to JB#46913

Imported from commit 660786bb of jolla-settings-account.

That's a proposition. It is using the same approach as in jolla-settings-account : the paths, percent encoded or not, are saved like sent by the server in the href XML element of the responses. But when these paths are used in a request, the percent encoding status is checked and treated accordingly to create the request URL.

Compared to the original commit this patch is based on, I'm not testing for the "%40" encoded character, but simply for '%' in general, because as far as I understand, a valid URI can be encoded (so with % characters), or decoded. In the latter case, it cannot contain any unsafe characters, as defined in https://datatracker.ietf.org/doc/html/rfc2068#section-3.2.1.

I think it's better comforming to the RFC like that.