### PR TITLE
[buteo-sync-plugin-caldav] Always use decoded paths.

### DIFF
--- a/lib/propfind.cpp
+++ b/lib/propfind.cpp
@@ -27,6 +27,7 @@
 #include <QNetworkAccessManager>
 #include <QBuffer>
 #include <QXmlStreamReader>
+#include <QUrl>
 
 #define PROP_URI "uri"
 
@@ -148,7 +149,7 @@ static bool readCalendarProp(QXmlStreamReader *reader, bool *isCalendar,
         } else if (reader->name() == "current-user-principal" && reader->isStartElement()) {
             for (;!reader->atEnd(); reader->readNext()) {
                 if (reader->name() == "href" && reader->isStartElement()) {
-                    currentUserPrincipal = reader->readElementText();
+                    currentUserPrincipal = QUrl::fromPercentEncoding(reader->readElementText().toUtf8());
                     break;
                 } else if (reader->name() == "current-user-principal" && reader->isEndElement()) {
                     break;
@@ -244,9 +245,7 @@ static bool readCalendarsResponse(QXmlStreamReader *reader, QList<Buteo::Dav::Ca
     Buteo::Dav::CalendarInfo calendarInfo;
     for (; !reader->atEnd(); reader->readNext()) {
         if (reader->name() == "href" && reader->isStartElement() && calendarInfo.remotePath.isEmpty()) {
-            // The account stores this with the encoding, so we're converting from
-            // percent encoding later.
-            calendarInfo.remotePath = reader->readElementText();
+            calendarInfo.remotePath = QUrl::fromPercentEncoding(reader->readElementText().toUtf8());
         }
 
         if (reader->name() == "propstat" && reader->isStartElement()) {
@@ -333,14 +332,14 @@ static bool readUserAddressSetResponse(QXmlStreamReader *reader,
                    && (set->mailto.isEmpty()
                        || reader->attributes().value(QStringLiteral("preferred")) == "1")) {
             valid = true;
-            QString href = reader->readElementText();
+            QString href = QUrl::fromPercentEncoding(reader->readElementText().toUtf8());
             if (href.startsWith(QStringLiteral("mailto:"), Qt::CaseInsensitive)) {
                 set->mailto = href.mid(7); // chop off "mailto:"
             }
         } else if (canReadHomeHref
                    && reader->name() == "href" && reader->isStartElement()) {
             valid = true;
-            set->path = reader->readElementText();
+            set->path = QUrl::fromPercentEncoding(reader->readElementText().toUtf8());
         } else if (reader->name() == "propstat" && reader->isEndElement()) {
             return valid;
         }
@@ -385,7 +384,7 @@ static bool readUserPrincipalResponse(QXmlStreamReader *reader, QString *userPri
         } else if (reader->name() == "href"
                 && reader->isStartElement()
                 && canReadUserPrincipalHref) {
-            href = reader->readElementText();
+            href = QUrl::fromPercentEncoding(reader->readElementText().toUtf8());
         }
     }
 

--- a/lib/reader.cpp
+++ b/lib/reader.cpp
@@ -130,7 +130,7 @@ void Reader::readResponse()
     Buteo::Dav::Resource resource;
     while (mReader->readNextStartElement()) {
         if (mReader->name() == "href") {
-            resource.href = QUrl::fromPercentEncoding(mReader->readElementText().toLatin1());
+            resource.href = QUrl::fromPercentEncoding(mReader->readElementText().toUtf8());
         } else if (mReader->name() == "propstat") {
             readPropStat(&resource);
         } else if (mReader->name() == "status") {

--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -286,7 +286,16 @@ public:
             colors.clear();
             enabled.clear();
         }
-    };
+        // Paths in settings are always saved encoded (for backward compatibility reasons).
+        QStringList decoded;
+        for (const QString &path : paths)
+            decoded << QUrl::fromPercentEncoding(path.toUtf8());
+        paths = decoded;
+        decoded.clear();
+        for (const QString &path : enabled)
+            decoded << QUrl::fromPercentEncoding(path.toUtf8());
+        enabled = decoded;
+    }
     // Constructs a list of CalendarInfo from value stored in settings.
     QList<Buteo::Dav::CalendarInfo> toCalendars() const
     {
@@ -296,7 +305,7 @@ public:
                                                         QString(), colors[i]);
         }
         return allCalendarInfo;
-    };
+    }
     QList<Buteo::Dav::CalendarInfo> enabledCalendars(const QList<Buteo::Dav::CalendarInfo> &calendars) const
     {
         QList<Buteo::Dav::CalendarInfo> filteredCalendarInfo;
@@ -307,14 +316,14 @@ public:
             filteredCalendarInfo << info;
         }
         return filteredCalendarInfo;
-    };
+    }
     void add(const Buteo::Dav::CalendarInfo &infos)
     {
         paths.append(infos.remotePath);
         enabled.append(infos.remotePath);
         displayNames.append(infos.displayName);
         colors.append(infos.color);
-    };
+    }
     bool update(const Buteo::Dav::CalendarInfo &infos, bool &modified)
     {
         int i = paths.indexOf(infos.remotePath);
@@ -327,7 +336,7 @@ public:
             modified = true;
         }
         return true;
-    };
+    }
     bool remove(const QString &path)
     {
         int at = paths.indexOf(path);
@@ -341,14 +350,22 @@ public:
     }
     void store(Accounts::Account *account, const Accounts::Service &srv)
     {
+        // For backward compatibility reasons, remote paths are always saved
+        // encoded. Previously, they were decoded in the NotebookSyncAgent constructor.
+        QStringList encoded;
         account->selectService(srv);
-        account->setValue("calendars", paths);
+        for (const QString &path : paths)
+            encoded << QString::fromUtf8(QUrl::toPercentEncoding(path));
+        account->setValue("calendars", encoded);
+        encoded.clear();
+        for (const QString &path : enabled)
+            encoded << QString::fromUtf8(QUrl::toPercentEncoding(path));
         account->setValue("enabled_calendars", enabled);
         account->setValue("calendar_display_names", displayNames);
         account->setValue("calendar_colors", colors);
         account->selectService(Accounts::Service());
         account->syncAndBlock();
-    };
+    }
 private:
     QStringList paths;
     QStringList displayNames;

--- a/src/notebooksyncagent.cpp
+++ b/src/notebooksyncagent.cpp
@@ -390,7 +390,7 @@ namespace {
 NotebookSyncAgent::NotebookSyncAgent(mKCal::ExtendedCalendar::Ptr calendar,
                                      mKCal::ExtendedStorage::Ptr storage,
                                      Buteo::Dav::Client *davClient,
-                                     const QString &encodedRemotePath,
+                                     const QString &remotePath,
                                      bool readOnlyFlag,
                                      QObject *parent)
     : QObject(parent)
@@ -398,7 +398,7 @@ NotebookSyncAgent::NotebookSyncAgent(mKCal::ExtendedCalendar::Ptr calendar,
     , mCalendar(calendar)
     , mStorage(storage)
     , mNotebook(0)
-    , mEncodedRemotePath(encodedRemotePath)
+    , mRemoteCalendarPath(remotePath)
     , mSyncMode(NoSyncMode)
     , mRetriedReport(false)
     , mNotebookNeedsDeletion(false)
@@ -406,8 +406,6 @@ NotebookSyncAgent::NotebookSyncAgent(mKCal::ExtendedCalendar::Ptr calendar,
     , mEnableDownsync(true)
     , mReadOnlyFlag(readOnlyFlag)
 {
-    // the calendar path may be percent-encoded.  Return UTF-8 QString.
-    mRemoteCalendarPath = QUrl::fromPercentEncoding(mEncodedRemotePath.toUtf8());
     // Yahoo! seems to double-percent-encode for some reason
     if (mDAV->serverAddress().contains(QStringLiteral("caldav.calendar.yahoo.com"))) {
         mRemoteCalendarPath = QUrl::fromPercentEncoding(mRemoteCalendarPath.toUtf8());
@@ -994,7 +992,7 @@ bool NotebookSyncAgent::hasUploadErrors() const
 
 const QString& NotebookSyncAgent::path() const
 {
-    return mEncodedRemotePath;
+    return mRemoteCalendarPath;
 }
 
 // ------------------------------ Utility / implementation functions.

--- a/src/notebooksyncagent.h
+++ b/src/notebooksyncagent.h
@@ -43,12 +43,12 @@ public:
         QuickSync   // updates only
     };
 
-    explicit NotebookSyncAgent(mKCal::ExtendedCalendar::Ptr calendar,
-                               mKCal::ExtendedStorage::Ptr storage,
-                               Buteo::Dav::Client *davClient,
-                               const QString &encodedRemotePath,
-                               bool readOnlyFlag = false,
-                               QObject *parent = 0);
+    NotebookSyncAgent(mKCal::ExtendedCalendar::Ptr calendar,
+                      mKCal::ExtendedStorage::Ptr storage,
+                      Buteo::Dav::Client *davClient,
+                      const QString &remotePath,
+                      bool readOnlyFlag = false,
+                      QObject *parent = 0);
     ~NotebookSyncAgent();
 
     bool setNotebookFromInfo(const Buteo::Dav::CalendarInfo &info,
@@ -131,7 +131,6 @@ private:
     QDateTime mFromDateTime;
     QDateTime mToDateTime;
     QDateTime mNotebookSyncedDateTime;
-    QString mEncodedRemotePath;
     QString mRemoteCalendarPath; // contains calendar path.  resource prefix.  doesn't include host, percent decoded.
     SyncMode mSyncMode;          // quick (etag-based delta detection) or slow (full report) sync
     bool mRetriedReport;         // some servers will fail the first request but succeed on second


### PR DESCRIPTION
Make Buteo::Dav routines always returning decoded
paths for 'href' entries in responses.

Adjust the synchronisation code to assume decoded
paths from the dav client.

@pvuorela , this is a commit trying to rationalise the encoded / decoded situation of paths returned by the DAV client library. It's definitely cleaner to go that direction, but I'm afraid it's quite fragile with respect to existing account settings. It's also quite difficult to est, because I didn't find any services I can have access to that uses percent encoding in their responses.

This is not necessary to be included, but more of a comparison with the approach used up to now and proposed in #34.