### PR TITLE
Don't encode '/' in paths and fix tests.

### DIFF
--- a/src/caldavclient.cpp
+++ b/src/caldavclient.cpp
@@ -355,11 +355,11 @@ public:
         QStringList encoded;
         account->selectService(srv);
         for (const QString &path : paths)
-            encoded << QString::fromUtf8(QUrl::toPercentEncoding(path));
+            encoded << QString::fromUtf8(QUrl::toPercentEncoding(path, "/"));
         account->setValue("calendars", encoded);
         encoded.clear();
         for (const QString &path : enabled)
-            encoded << QString::fromUtf8(QUrl::toPercentEncoding(path));
+            encoded << QString::fromUtf8(QUrl::toPercentEncoding(path, "/"));
         account->setValue("enabled_calendars", enabled);
         account->setValue("calendar_display_names", displayNames);
         account->setValue("calendar_colors", colors);

--- a/tests/caldavclient/tst_caldavclient.cpp
+++ b/tests/caldavclient/tst_caldavclient.cpp
@@ -168,7 +168,7 @@ void tst_CalDavClient::loadAccountCalendars()
     const QList<Buteo::Dav::CalendarInfo> &calendars = client.loadAccountCalendars();
 
     QCOMPARE(calendars.count(), 1);
-    QCOMPARE(calendars.first().remotePath, QLatin1String("/bar%40plop/"));
+    QCOMPARE(calendars.first().remotePath, QLatin1String("/bar@plop/"));
     QCOMPARE(calendars.first().displayName, QLatin1String("Bar"));
     QCOMPARE(calendars.first().color, QLatin1String("#00FF00"));
     QVERIFY(calendars.first().userPrincipal.isEmpty());
@@ -181,21 +181,21 @@ void tst_CalDavClient::mergeAccountCalendars()
     QVERIFY(client.init());
 
     QList<Buteo::Dav::CalendarInfo> remoteCalendars;
-    remoteCalendars << Buteo::Dav::CalendarInfo{QLatin1String("/bar%40plop/"),
+    remoteCalendars << Buteo::Dav::CalendarInfo{QLatin1String("/bar@plop/"),
             QLatin1String("Bar"), QString(), QLatin1String("#0000FF"), QLatin1String("/principals/2")};
     remoteCalendars << Buteo::Dav::CalendarInfo{QLatin1String("/foo/"),
             QLatin1String("New foo"), QString(), QLatin1String("#FF0000"), QString()};
-    remoteCalendars << Buteo::Dav::CalendarInfo{QLatin1String("/toto%40tutu/"),
+    remoteCalendars << Buteo::Dav::CalendarInfo{QLatin1String("/toto@tutu/"),
             QLatin1String("Toto"), QString(), QLatin1String("#FF00FF"), QString()};
 
     const QList<Buteo::Dav::CalendarInfo> &calendars = client.mergeAccountCalendars(remoteCalendars);
 
     QCOMPARE(calendars.count(), 2);
-    QCOMPARE(calendars[0].remotePath, QLatin1String("/bar%40plop/"));
+    QCOMPARE(calendars[0].remotePath, QLatin1String("/bar@plop/"));
     QCOMPARE(calendars[0].displayName, QLatin1String("Bar"));
     QCOMPARE(calendars[0].color, QLatin1String("#0000FF"));
     QCOMPARE(calendars[0].userPrincipal, QLatin1String("/principals/2"));
-    QCOMPARE(calendars[1].remotePath, QLatin1String("/toto%40tutu/"));
+    QCOMPARE(calendars[1].remotePath, QLatin1String("/toto@tutu/"));
     QCOMPARE(calendars[1].displayName, QLatin1String("Toto"));
     QCOMPARE(calendars[1].color, QLatin1String("#FF00FF"));
     QVERIFY(calendars[1].userPrincipal.isEmpty());
@@ -218,13 +218,13 @@ void tst_CalDavClient::removeAccountCalendar()
     client.mManager = mManager; // So we can share the same Account pointers.
     QVERIFY(client.init());
 
-    client.removeAccountCalendars(QStringList() << QLatin1String("/bar%40plop/") << QLatin1String("/notStoredOne/"));
+    client.removeAccountCalendars(QStringList() << QLatin1String("/bar@plop/") << QLatin1String("/notStoredOne/"));
 
     Accounts::Service srv = mAccount->services(QLatin1String("caldav")).first();
     mAccount->selectService(srv);
     const QStringList &allCalendars = mAccount->value("calendars").toStringList();
     QCOMPARE(allCalendars.count(), 2);
-    QVERIFY(!allCalendars.contains(QLatin1String("/bar%40plop/")));
+    QVERIFY(!allCalendars.contains(QLatin1String("/bar@plop/")));
     const QStringList &names = mAccount->value("calendar_display_names").toStringList();
     QCOMPARE(names.count(), 2);
     QVERIFY(!names.contains(QLatin1String("Bar")));

--- a/tests/propfind/tst_propfind.cpp
+++ b/tests/propfind/tst_propfind.cpp
@@ -106,7 +106,7 @@ void tst_Propfind::parseUserPrincipalResponse_data()
     QTest::newRow("valid response")
         << QByteArray("<?xml version='1.0' encoding='utf-8'?><D:multistatus xmlns:D='DAV:'><D:response><D:href>/</D:href><D:propstat><D:prop><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>")
         << true
-        << QString::fromLatin1("/principals/users/username%40server.tld/");
+        << QString::fromLatin1("/principals/users/username@server.tld/");
 }
 
 void tst_Propfind::parseUserPrincipalResponse()
@@ -202,7 +202,7 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar 0"),
                     QString(),
                     QString::fromLatin1("#FF0000"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/")});
+                    QString::fromLatin1("/principals/users/username@server.tld/")});
 
     QTest::newRow("one read-only calendar")
         << QByteArray("<?xml version='1.0' encoding='utf-8'?><D:multistatus xmlns:D='DAV:' xmlns:c='urn:ietf:params:xml:ns:caldav'><D:response><D:href>/calendars/0/</D:href><D:propstat><D:prop><D:displayname>Calendar 0</D:displayname><calendar-color xmlns=\"http://apple.com/ns/ical/\">#FF0000</calendar-color><D:resourcetype><c:calendar /><D:collection /></D:resourcetype><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal><D:current-user-privilege-set><D:privilege><D:read /></D:privilege></D:current-user-privilege-set></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>")
@@ -212,7 +212,7 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar 0"),
                     QString(),
                     QString::fromLatin1("#FF0000"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/"),
+                    QString::fromLatin1("/principals/users/username@server.tld/"),
                     Buteo::Dav::READ});
 
     QTest::newRow("missing current-user-principal")
@@ -233,7 +233,7 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar"),
                     QString(),
                     QString::fromLatin1("#FF0000"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/")});
+                    QString::fromLatin1("/principals/users/username@server.tld/")});
 
     QTest::newRow("missing privileges")
         << QByteArray("<?xml version='1.0' encoding='utf-8'?><D:multistatus xmlns:D='DAV:' xmlns:c='urn:ietf:params:xml:ns:caldav'><D:response><D:href>/calendars/0/</D:href><D:propstat><D:prop><D:displayname>Calendar 0</D:displayname><calendar-color xmlns=\"http://apple.com/ns/ical/\">#FF0000</calendar-color><D:resourcetype><c:calendar /><D:collection /></D:resourcetype><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat><D:propstat><D:prop><D:current-user-privilege-set /></D:prop><D:status>HTTP/1.1 404</D:status></D:propstat></D:response></D:multistatus>")
@@ -243,7 +243,7 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar 0"),
                     QString(),
                     QString::fromLatin1("#FF0000"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/")});
+                    QString::fromLatin1("/principals/users/username@server.tld/")});
 
     QTest::newRow("two valid calendars")
         << QByteArray("<?xml version='1.0' encoding='utf-8'?><D:multistatus xmlns:D='DAV:' xmlns:c='urn:ietf:params:xml:ns:caldav'><D:response><D:href>/calendars/0/</D:href><D:propstat><D:prop><D:displayname>Calendar 0</D:displayname><calendar-color xmlns=\"http://apple.com/ns/ical/\">#FF0000</calendar-color><D:resourcetype><c:calendar /><D:collection /></D:resourcetype><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response><D:response><D:href>/calendars/1/</D:href><D:propstat><D:prop><D:displayname>Calendar 1</D:displayname><calendar-color xmlns=\"http://apple.com/ns/ical/\">#FFFF00</calendar-color><D:resourcetype><c:calendar /><D:collection /></D:resourcetype><D:current-user-principal><D:href>/principals/users/username%40server.tld/</D:href></D:current-user-principal></D:prop><D:status>HTTP/1.1 200 OK</D:status></D:propstat></D:response></D:multistatus>")
@@ -253,19 +253,19 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar 0"),
                     QString(),
                     QString::fromLatin1("#FF0000"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/")}
+                    QString::fromLatin1("/principals/users/username@server.tld/")}
             << Buteo::Dav::CalendarInfo{
                 QString::fromLatin1("/calendars/1/"),
                     QString::fromLatin1("Calendar 1"),
                     QString(),
                     QString::fromLatin1("#FFFF00"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/")});
+                    QString::fromLatin1("/principals/users/username@server.tld/")});
 
     Buteo::Dav::CalendarInfo todos(QString::fromLatin1("/calendars/0/"),
                                    QString::fromLatin1("Calendar 0"),
                                    QString(),
                                    QString::fromLatin1("#FF0000"),
-                                   QString::fromLatin1("/principals/users/username%40server.tld/"));
+                                   QString::fromLatin1("/principals/users/username@server.tld/"));
     todos.allowEvents = false;
     todos.allowTodos = true;
     todos.allowJournals = false;
@@ -282,7 +282,7 @@ void tst_Propfind::parseCalendarResponse_data()
                     QString::fromLatin1("Calendar"),
                     QString(),
                     QString::fromLatin1("#FF0000"),
-                    QString::fromLatin1("/principals/users/username%40server.tld/")});
+                    QString::fromLatin1("/principals/users/username@server.tld/")});
 }
 
 void tst_Propfind::parseCalendarResponse()


### PR DESCRIPTION
Paths encoded in settings should not encode the '/'
    character.
    
    Paths stored in DAV library structures are always
    decoded since previous commit. Update the test
    references accordingly.
