### PR TITLE
Try to better handle redirections in calendar inquiries

### DIFF
--- a/lib/davclient.cpp
+++ b/lib/davclient.cpp
@@ -287,7 +287,14 @@ void Buteo::Dav::Client::requestUserPrincipalAndServiceData(const QString &servi
             emit userPrincipalDataFinished(reply(*userRequest, uri));
         }
     });
-    userRequest->listCurrentUserPrincipal(ensureRoot(davPath));
+    if (davPath.isEmpty()) {
+        // The server address may have been given with a path,
+        // at construction time, like https://domain.org/path/to/dav.
+        QUrl url(d->m_settings.serverAddress());
+        userRequest->listCurrentUserPrincipal(ensureRoot(url.path()));
+    } else {
+        userRequest->listCurrentUserPrincipal(ensureRoot(davPath));
+    }
 }
 
 /*!

--- a/lib/davclient.cpp
+++ b/lib/davclient.cpp
@@ -95,7 +95,8 @@ public:
 
     Settings m_settings;
     QNetworkAccessManager *m_networkManager;
-    bool m_wellKnowRetryInProgress = false;
+    bool m_wellKnownRetryInProgress = false;
+    QString m_serverAddressBeforeWellKnown;
     QString m_userPrincipal;
     QMap<QString, PropFind::UserAddressSet> m_serviceData;
     QList<Buteo::Dav::CalendarInfo> m_calendars;
@@ -250,11 +251,11 @@ void Buteo::Dav::Client::requestUserPrincipalAndServiceData(const QString &servi
                 if (!hrefsRequest->hasError()) {
                     d->m_serviceData = hrefsRequest->userAddressSets();
                 }
-                d->m_wellKnowRetryInProgress = false;
+                d->m_wellKnownRetryInProgress = false;
                 emit userPrincipalDataFinished(reply(*hrefsRequest, uri));
             });
             hrefsRequest->listUserAddressSet(userPrincipal, service);
-        } else if (!service.isEmpty() && !d->m_wellKnowRetryInProgress) {
+        } else if (!service.isEmpty() && !d->m_wellKnownRetryInProgress) {
             // Can't find a user principal, try with a .well-known redirection.
             Head *serviceRequest = new Head(d->m_networkManager, &d->m_settings, this);
             connect(serviceRequest, &Request::finished, this,
@@ -263,10 +264,12 @@ void Buteo::Dav::Client::requestUserPrincipalAndServiceData(const QString &servi
 
                 if (!serviceRequest->hasError()) {
                     const QUrl url = serviceRequest->serviceUrl(service);
+                    // Save server address in case the redirection doesn't help.
+                    d->m_serverAddressBeforeWellKnown = d->m_settings.serverAddress();
                     // Redirection may point to a different [sub]domain.
                     d->m_settings.setServerAddress(QString::fromLatin1("%1://%2").arg(url.scheme()).arg(url.host()));
                     // Retry to get a user principal using the provided redirect.
-                    d->m_wellKnowRetryInProgress = true;
+                    d->m_wellKnownRetryInProgress = true;
                     requestUserPrincipalAndServiceData(service, url.path());
                 } else {
                     emit userPrincipalDataFinished(reply(*serviceRequest, uri));
@@ -274,7 +277,13 @@ void Buteo::Dav::Client::requestUserPrincipalAndServiceData(const QString &servi
             });
             serviceRequest->getServiceUrl(service);
         } else {
-            d->m_wellKnowRetryInProgress = false;
+            if (!d->m_serverAddressBeforeWellKnown.isEmpty()) {
+                // The redirection didn't help to get the user principal,
+                // so restore the server address.
+                d->m_settings.setServerAddress(d->m_serverAddressBeforeWellKnown);
+                d->m_serverAddressBeforeWellKnown.clear();
+            }
+            d->m_wellKnownRetryInProgress = false;
             emit userPrincipalDataFinished(reply(*userRequest, uri));
         }
     });

--- a/lib/propfind.cpp
+++ b/lib/propfind.cpp
@@ -23,6 +23,7 @@
 
 #include "propfind_p.h"
 #include "settings_p.h"
+#include "logging_p.h"
 
 #include <QNetworkAccessManager>
 #include <QBuffer>
@@ -519,7 +520,9 @@ void PropFind::sendRequest(const QString &remotePath, const QByteArray &requestD
 void PropFind::handleReply(QNetworkReply *reply)
 {
     const QString &uri = reply->property(PROP_URI).toString();
-    if (reply->error() != QNetworkReply::NoError) {
+    if (reply->error() != QNetworkReply::NoError
+        && (mPropFindRequestType != UserPrincipal
+            || reply->attribute(QNetworkRequest::HttpStatusCodeAttribute) != 301)) {
         finishedWithReplyResult(uri, reply);
         return;
     }
@@ -529,9 +532,24 @@ void PropFind::handleReply(QNetworkReply *reply)
     bool success = false;
 
     switch (mPropFindRequestType) {
-    case (UserPrincipal):
-        success = parseUserPrincipalResponse(data);
+    case (UserPrincipal): {
+        const QUrl location = reply->attribute(QNetworkRequest::RedirectionTargetAttribute).toUrl();
+        if (location.isValid()) {
+            /* Case where the user principal request redirects to
+               another [sub]domain, or server path. For instance:
+               PROPFIND at https://user:pass@calendar.domain.fi/
+               returns a 301 response with
+               Location : https://calendar.domain.fi/SOGo. */
+            mSettings->setServerAddress(QString::fromLatin1("%1://%2").arg(location.scheme(), location.host()));
+            qCDebug(lcDav) << "user principal redirection to" << mSettings->serverAddress()
+                           << ", restarting PROPFIND on path" << location.path();
+            listCurrentUserPrincipal(location.path());
+            return;
+        } else {
+            success = parseUserPrincipalResponse(data);
+        }
         break;
+    }
     case (UserAddresses):
         success = parseUserAddressSetResponse(data);
         break;


### PR DESCRIPTION
These two commits try to address the issue observed in the log reported on the forum : https://forum.sailfishos.org/t/release-notes-pispala-5-1-0-8-early-access/29751/271

In the logs, the first request is done on https://calendar.domain.fi/, which returns a redirection to https://calendar.domain.fi/SOGo/. The code is not handling the redirection, which leads it to try the .well-known scheme to get the caldav service path on the server.

This .well-known HEAD request is succeeding and redirect to http://calendar.domain.fi/SOGo/, notice the http:// without ‘s’ in the redirection. Getting this redirection, the code updates the server path, using the provided one in the redirection, which scratch the https://. Then, the code resumes it’s normal routine, by inquiring the user principal at the given server path (with the http://). This redirects to https://, but the code doesn’t honour redirection outside of .well-known scheme.

So finally, the code gives up with autodetection of the calendars, and try to apply the stored calendar paths, which are correct. But the previous .well-known scheme answer had changed the server to http://, which makes everything fails, because the server refuses (rightly) to serve authenticated data on http.

So in my opinion, there are two issues at hand:
1. the PROPFIND to get the user principal in not handling 301 response and redirection,
2. in case the .well-known redirection is mis configured (like here, returning a http:// location), reverting the server address change may be safer than continuing with a wrong server address.

The two commits should address these two issues:
1. first commit is adding redirection to the user principal PROPFIND request (I've tested it as described in the commit message by trying to reach my CalDAV provider over http),
2. second commit is adding a revert to the setting changes. This one I cannot test.

@pvuorela, what do you think ?