### PR TITLE
[buteo-sync-plugin-caldav] Send basic auth on request.

### DIFF
--- a/lib/propfind.cpp
+++ b/lib/propfind.cpp
@@ -524,7 +524,9 @@ void PropFind::handleReply(QNetworkReply *reply)
     const QString &uri = reply->property(PROP_URI).toString();
     if (reply->error() != QNetworkReply::NoError
         && (mPropFindRequestType != UserPrincipal
-            || reply->attribute(QNetworkRequest::HttpStatusCodeAttribute) != 301)) {
+            || reply->attribute(QNetworkRequest::HttpStatusCodeAttribute) != 301)
+        && (mPropFindRequestType != UserPrincipal
+            || !reply->property("ShouldRetry").toBool())) {
         finishedWithReplyResult(uri, reply);
         return;
     }
@@ -548,6 +550,13 @@ void PropFind::handleReply(QNetworkReply *reply)
             qCDebug(lcDav) << "user principal redirection to" << mSettings->serverAddress()
                            << ", restarting PROPFIND on path" << location.path();
             listCurrentUserPrincipal(location.path());
+            return;
+        } else if (reply->property("ShouldRetry").toBool()) {
+            /* Case where the server request to re-authenticate using a
+               Basic mechanism. */
+            qCDebug(lcDav) << "user principal authentication request"
+                           << ", restarting PROPFIND on path" << reply->url().path();
+            listCurrentUserPrincipal(reply->url().path());
             return;
         } else {
             success = parseUserPrincipalResponse(data);

--- a/lib/request.cpp
+++ b/lib/request.cpp
@@ -107,6 +107,19 @@ void Request::requestFinished()
 
     qCDebug(lcDav) << command() << "request finished:" << reply->error();
 
+    // Should be handled by connecting from the DAV client to
+    // QNetworkAccessManager::authenticationRequired but current Qt
+    // implementation does not support UTF-8 Basic authentication.
+    if (reply->error() == QNetworkReply::AuthenticationRequiredError) {
+        const QByteArray authChallenge = reply->rawHeader("WWW-Authenticate");
+        if (authChallenge.startsWith("Basic ") && mSettings->authBasic().isEmpty()) {
+            // RFC7617 mention that the 'charset' parameter is optional,
+            // but it's only allowed value is "UTF-8".
+            mSettings->useAuthBasic(authChallenge.contains("charset="));
+            reply->setProperty("ShouldRetry", true);
+        }
+    }
+
     handleReply(reply);
 }
 
@@ -138,14 +151,11 @@ void Request::prepareRequest(QNetworkRequest *request, const QString &requestPat
     QUrl url(mSettings->serverAddress());
 
     if (!mSettings->authToken().isEmpty()) {
-        request->setRawHeader(QString("Authorization").toLatin1(),
+        request->setRawHeader(QByteArray("Authorization"),
                               QString("Bearer " + mSettings->authToken()).toLatin1());
-    } else if (mSettings->serverAddress().endsWith(QStringLiteral(".yahoo.com"))
-               || mSettings->serverAddress().endsWith(QStringLiteral(".icloud.com"))) {
-        request->setRawHeader(QString("Authorization").toLatin1(),
-                              QByteArray("Basic ")
-                              + QString::fromLatin1("%1:%2").arg(mSettings->username())
-                                                            .arg(mSettings->password()).toLatin1().toBase64());
+    } else if (!mSettings->authBasic().isEmpty()) {
+        request->setRawHeader(QByteArray("Authorization"),
+                              QByteArray("Basic ") + mSettings->authBasic().toBase64());
     } else {
         url.setUserName(mSettings->username());
         url.setPassword(mSettings->password());

--- a/lib/settings.cpp
+++ b/lib/settings.cpp
@@ -38,6 +38,22 @@ void Settings::setAuthToken(const QString & token)
     mOAuthToken = token;
 }
 
+QByteArray Settings::authBasic() const
+{
+    if (mBasicAuthLegacy)
+        return username().toLatin1() + ':' + password().toLatin1();
+    else if (mBasicAuthUtf8)
+        return username().toUtf8() + ':' + password().toUtf8();
+    else
+        return QByteArray();
+}
+
+void Settings::useAuthBasic(bool inUtf8)
+{
+    mBasicAuthLegacy = !inUtf8;
+    mBasicAuthUtf8 = inUtf8;
+}
+
 bool Settings::ignoreSSLErrors() const
 {
     return mIgnoreSSLErrors;
@@ -71,6 +87,9 @@ void Settings::setUsername(const QString & username)
 void Settings::setServerAddress(const QString &serverAddress)
 {
     mServerAddress = serverAddress;
+    if (serverAddress.endsWith(QStringLiteral(".yahoo.com"))
+        || serverAddress.endsWith(QStringLiteral(".icloud.com")))
+        useAuthBasic();
 }
 
 QString Settings::serverAddress() const

--- a/lib/settings_p.h
+++ b/lib/settings_p.h
@@ -41,6 +41,9 @@ public:
     void setPassword(const QString &password);
     QString password() const;
 
+    QByteArray authBasic() const;
+    void useAuthBasic(bool inUtf8 = false);
+
     void setIgnoreSSLErrors(bool ignore);
     bool ignoreSSLErrors() const;
 
@@ -53,6 +56,8 @@ private:
     QString mUsername;
     QString mPassword;
     bool mIgnoreSSLErrors;
+    bool mBasicAuthLegacy = false;
+    bool mBasicAuthUtf8 = false;
 };
 
 #endif // SETTINGS_H


### PR DESCRIPTION
Some servers don't accept non-ASCII characters
in the password when given in the URL (even properly percent encoded). They reply with a 401 status
and a challenge with a www-authentication header.

Listen to this challenge and provide credentials
in the handler. Notice that Qt is constructing
the response assuming Latin1 encoded strings,
see QAuthenticatorPrivate::calculateResponse
from Qt sources. To avoid problems with non-ASCII
characters in the password and assuming the
server expect UTF-8 encoded strings, transform
the UTF-8 representation into latin1 before
passing it to the authenticator.

@pvuorela , this is coming from https://forum.sailfishos.org/t/non-ascii-characters-in-nextcloud-account-password/29927. If you have a Nextcloud account somewhere, change your password to use non-ASCII (and non-Latin1) characters. Then try to list calendars with:
```
QT_LOGGING_RULES="*.debug=true" ./dav-client -u <login> -P "<pass>" -S caldav -s https://nextcloud.instance.dom --list-calendars ""
```

I find it quite incredible that basic authentication is expecting password in latin1, even in Qt6. But well…
Another possibility, would be to avoid this signal stuff, could be to always send the authentication header. As far as I know, curl is doing this by default : if you provide a url with credentials, it is forging a header and sending it.

Another point: this kind of stuff is also happening in the Nextcloud account code, but I still didn't investigate much there. @nephros did it, see the forum discussion.