### PR TITLE
[buteo-sync-plugin-caldav] Handle relative redirections in PROPFIND.

### DIFF
--- a/lib/propfind.cpp
+++ b/lib/propfind.cpp
@@ -539,8 +539,10 @@ void PropFind::handleReply(QNetworkReply *reply)
                another [sub]domain, or server path. For instance:
                PROPFIND at https://user:pass@calendar.domain.fi/
                returns a 301 response with
-               Location : https://calendar.domain.fi/SOGo. */
-            mSettings->setServerAddress(QString::fromLatin1("%1://%2").arg(location.scheme(), location.host()));
+               Location : https://calendar.domain.fi/SOGo/
+               or Location : /SOGo/. */
+            if (!location.scheme().isEmpty())
+                mSettings->setServerAddress(QString::fromLatin1("%1://%2").arg(location.scheme(), location.host()));
             qCDebug(lcDav) << "user principal redirection to" << mSettings->serverAddress()
                            << ", restarting PROPFIND on path" << location.path();
             listCurrentUserPrincipal(location.path());


### PR DESCRIPTION
I'm sorry @pvuorela , I found another bug in the recent PR… One user on the Forum sent me logs that look like this:
```
[D] unknown:0 - “PROPFIND response status code: 302”
[D] unknown:0 - “PROPFIND response headers:”
[D] unknown:0 - “\tServer : nginx”
[D] unknown:0 - “\tDate : Mon, 15 Jun 2026 18:18:36 GMT”
[D] unknown:0 - “\tContent-Type : text/plain; charset=utf-8”
[D] unknown:0 - “\tContent-Length : 0”
[D] unknown:0 - “\tConnection : keep-alive”
[D] unknown:0 - “\tReferrer-Policy : same-origin”
[D] unknown:0 - “\tLocation : /SOGo/”
```
So with a relative redirection. Obviously, I tested only the case with a redirection including scheme and server address and forgot about the possibility of relative redirection.

The attached PR should handle both cases. I don't have a server at hand that provide a relative redirection, I've only tested that full server redirection is still working.