### PR TITLE
[buteo-sync-plugin-caldav] Handle relative redirections in HEAD.

### DIFF
--- a/lib/davclient.cpp
+++ b/lib/davclient.cpp
@@ -265,10 +265,12 @@ void Buteo::Dav::Client::requestUserPrincipalAndServiceData(const QString &servi
 
                 if (!serviceRequest->hasError()) {
                     const QUrl url = serviceRequest->serviceUrl(service);
-                    // Save server address in case the redirection doesn't help.
-                    d->m_serverAddressBeforeWellKnown = d->m_settings.serverAddress();
                     // Redirection may point to a different [sub]domain.
-                    d->m_settings.setServerAddress(QString::fromLatin1("%1://%2").arg(url.scheme()).arg(url.host()));
+                    if (!url.scheme().isEmpty()) {
+                        // Save server address in case the redirection doesn't help.
+                        d->m_serverAddressBeforeWellKnown = d->m_settings.serverAddress();
+                        d->m_settings.setServerAddress(QString::fromLatin1("%1://%2").arg(url.scheme()).arg(url.host()));
+                    }
                     // Retry to get a user principal using the provided redirect.
                     d->m_wellKnownRetryInProgress = true;
                     requestUserPrincipalAndServiceData(service, url.path());


### PR DESCRIPTION
@pvuorela I got another issue with relative redirection, see this reply from a different user on the forum : https://forum.sailfishos.org/t/release-notes-pispala-5-1-0-11/29751/495

This time, the relative redirection is during the HEAD request, not in the PROPFIND. So I'm applying the same patch for this case too. This time, I grep for other occurrences of this redirection scheme, and I think we are covered now.

I'm sorry this is taking so many hops to get it correct…

By the way, thanks for the recent cleaning.